### PR TITLE
[feat] 프로젝트 상세 페이지에 메인으로 돌아가는 뒤로가기 버튼 추가

### DIFF
--- a/src/app/project/[projectName]/layout.tsx
+++ b/src/app/project/[projectName]/layout.tsx
@@ -1,7 +1,8 @@
+import Link from "next/link";
 import { PROJECTINFO } from "@/constants";
 
 // icon
-import { RiCalendar2Fill } from "@remixicon/react";
+import { RiCalendar2Fill, RiArrowLeftLine } from "@remixicon/react";
 
 export default async function ProjectLayout({
   params,
@@ -13,6 +14,10 @@ export default async function ProjectLayout({
   const { projectName } = await params;
   return (
     <div className="detail-wrapper">
+      <Link href="/" className="detail-back-btn" aria-label="메인으로 돌아가기">
+        <RiArrowLeftLine />
+        <span>메인으로</span>
+      </Link>
       <header className="detail-header">
         <div className="detail-header-txt-wrap">
           <h3>{PROJECTINFO[projectName].title}</h3>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -57,6 +57,50 @@ a {
   height: 22.5rem;
 }
 
+.detail-back-btn {
+  position: fixed;
+  top: 1.5rem;
+  left: 1.5rem;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.5rem 0.875rem;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.15);
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1;
+  backdrop-filter: blur(4px);
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
+
+  svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    fill: currentColor;
+  }
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.28);
+    transform: translateX(-2px);
+  }
+}
+
+@media (max-width: 600px) {
+  .detail-back-btn {
+    top: 1rem;
+    left: 1rem;
+    padding: 0.5rem;
+
+    span {
+      display: none;
+    }
+  }
+}
+
 .detail-header-txt-wrap {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
## 개요
프로젝트 상세 페이지에서 메인으로 돌아갈 수 있는 뒤로가기 버튼을 추가합니다.

## 변경 사항
- `src/app/project/[projectName]/layout.tsx` — 뒤로가기 버튼 배치
- `src/styles/global.scss` — 뒤로가기 버튼 스타일

## 대상 브랜치
`update/v1.1.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)